### PR TITLE
Cleanup whitespace, fix chmod & disallow php file-extensions

### DIFF
--- a/index.php
+++ b/index.php
@@ -298,6 +298,32 @@ $_CONFIG['upload_allow_type'] = array();
 //
 $_CONFIG['upload_reject_extension'] = array("php");
 
+//
+// By default, apply 0755 permissions to new directories
+//
+// The mode parameter consists of three octal number components specifying
+// access restrictions for the owner, the user group in which the owner is
+// in, and to everybody else in this order.
+//
+// See: https://php.net/manual/en/function.chmod.php
+//
+// Default: $_CONFIG['new_dir_mode'] = 0755;
+//
+$_CONFIG['new_dir_mode'] = 0755;
+
+//
+// By default, apply 0644 permissions to uploaded files
+//
+// The mode parameter consists of three octal number components specifying
+// access restrictions for the owner, the user group in which the owner is
+// in, and to everybody else in this order.
+//
+// See: https://php.net/manual/en/function.chmod.php
+//
+// Default: $_CONFIG['upload_file_mode'] = 0644;
+//
+$_CONFIG['upload_file_mode'] = 0644;
+
 /*
  * LOGGING
  */
@@ -2017,14 +2043,14 @@ class FileManager
 				// The target directory is not writable
 				$encodeExplorer->setErrorString("upload_dir_not_writable");
 			}
-			else if(!mkdir($location->getDir(true, false, false, 0).$dirname, 0777))
+			else if(!mkdir($location->getDir(true, false, false, 0).$dirname, EncodeExplorer::getConfig("new_dir_mode")))
 			{
 				// Error creating a new directory
 				$encodeExplorer->setErrorString("new_dir_failed");
 			}
-			else if(!chmod($location->getDir(true, false, false, 0).$dirname, 0777))
+			else if(!chmod($location->getDir(true, false, false, 0).$dirname, EncodeExplorer::getConfig("new_dir_mode")))
 			{
-				// Error applying chmod 777
+				// Error applying chmod
 				$encodeExplorer->setErrorString("chmod_dir_failed");
 			}
 			else
@@ -2079,7 +2105,7 @@ class FileManager
 		}
 		else
 		{
-			chmod($upload_file, 0755);
+			chmod($upload_file, EncodeExplorer::getConfig("upload_file_mode"));
 			Logger::logCreation($location->getDir(true, false, false, 0).$name, false);
 			Logger::emailNotification($location->getDir(true, false, false, 0).$name, true);
 		}

--- a/index.php
+++ b/index.php
@@ -296,7 +296,7 @@ $_CONFIG['upload_allow_type'] = array();
 // For example: $_CONFIG['upload_reject_extension'] = array("php", "html", "htm");
 // Default: $_CONFIG['upload_reject_extension'] = array();
 //
-$_CONFIG['upload_reject_extension'] = array("php");
+$_CONFIG['upload_reject_extension'] = array("php", "php2", "php3", "php4", "php5", "phtml");
 
 //
 // By default, apply 0755 permissions to new directories

--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@
  *                  Comments needed for configuring are in both estonian and english.
  *                  If you change anything, save with UTF-8! Otherwise you may
  *                  encounter problems, especially when displaying images.
- *                  
+ *
  *             NB!: Kommentaarid on inglise keeles.
  *                  Seadistamiseks vajalikud kommentaarid on eesti ja inglise keeles.
  *                  Kui midagi muudate, salvestage UTF-8 formaati! Vastasel juhul
@@ -31,8 +31,8 @@
  *   Encode Explorer is written in the hopes that it can be useful to people.
  *   It has NO WARRANTY and when you use it, the author is not responsible
  *   for how it works (or doesn't).
- *   
- *   The icon images are designed by Mark James (http://www.famfamfam.com) 
+ *
+ *   The icon images are designed by Mark James (http://www.famfamfam.com)
  *   and distributed under the Creative Commons Attribution 3.0 License.
  *
  ***************************************************************************/
@@ -53,7 +53,7 @@ $_CONFIG = array();
 $_ERROR = "";
 $_START_TIME = microtime(TRUE);
 
-/* 
+/*
  * GENERAL SETTINGS
  */
 
@@ -90,7 +90,7 @@ $_CONFIG['thumbnails_height'] = 300;
 //
 // Mobillidele mõeldud kasutajaliides. true/false
 // Vaikimisi: true
-// 
+//
 // Mobile interface enabled. true/false
 // Default: $_CONFIG['mobile_enabled'] = true;
 //
@@ -112,17 +112,17 @@ $_CONFIG['mobile_default'] = false;
 //
 // Kas failid avatakse uues aknas? true/false
 //
-// Will the files be opened in a new window? true/false 
+// Will the files be opened in a new window? true/false
 // Default: $_CONFIG['open_in_new_window'] = false;
 //
 $_CONFIG['open_in_new_window'] = false;
 
 //
-// Kui sügavalt alamkataloogidest suurust näitav script faile otsib? 
+// Kui sügavalt alamkataloogidest suurust näitav script faile otsib?
 // Määra see nullist suuremaks, kui soovid kogu kasutatud ruumi suurust kuvada.
 // Vaikimisi: 0
 //
-// How deep in subfolders will the script search for files? 
+// How deep in subfolders will the script search for files?
 // Set it larger than 0 to display the total used space.
 // Default: $_CONFIG['calculate_space_level'] = 0;
 //
@@ -132,7 +132,7 @@ $_CONFIG['calculate_space_level'] = 0;
 // Kas kuvatakse lehe päis? true/false
 // Vaikimisi: true;
 //
-// Will the page header be displayed? 0=no, 1=yes. 
+// Will the page header be displayed? 0=no, 1=yes.
 // Default: $_CONFIG['show_top'] = true;
 //
 $_CONFIG['show_top'] = true;
@@ -166,7 +166,7 @@ $_CONFIG['show_path'] = true;
 //
 // Kuva lehe laadimise aega. true/false
 // Vaikimisi: false
-// 
+//
 // Display the time it took to load the page.
 // Default: $_CONFIG['show_load_time'] = true;
 //
@@ -181,10 +181,10 @@ $_CONFIG['show_load_time'] = true;
 $_CONFIG['time_format'] = "d.m.y H:i:s";
 
 //
-// Kodeering, mida lehel kasutatakse. 
+// Kodeering, mida lehel kasutatakse.
 // Tuleb panna sobivaks, kui täpitähtedega tekib probleeme. Vaikimisi: UTF-8
 //
-// Charset. Use the one that suits for you. 
+// Charset. Use the one that suits for you.
 // Default: $_CONFIG['charset'] = "UTF-8";
 //
 $_CONFIG['charset'] = "UTF-8";
@@ -236,7 +236,7 @@ $_CONFIG['require_login'] = false;
 // The format is: array(username, password, status)
 // Status can be either "user" or "admin". User can read the page, admin can upload and delete.
 // For example: $_CONFIG['users'] = array(array("username1", "password1", "user"), array("username2", "password2", "admin"));
-// You can also keep require_login=false and specify an admin. 
+// You can also keep require_login=false and specify an admin.
 // That way everyone can see the page but username and password are needed for uploading.
 // For example: $_CONFIG['users'] = array(array("username", "password", "admin"));
 // Default: $_CONFIG['users'] = array();
@@ -269,7 +269,7 @@ $_CONFIG['delete_enable'] = false;
 // Kõik kaustad märgitute all on automaatselt kaasa arvatud.
 // Kui nimekiri on tühi (vaikimisi), siis on kõikidesse kaustadesse failide lisamine lubatud.
 //
-// List of directories where users are allowed to upload. 
+// List of directories where users are allowed to upload.
 // For example: $_CONFIG['upload_dirs'] = array("./myuploaddir1/", "./mydir/upload2/");
 // The path should be relative to the main directory, start with "./" and end with "/".
 // All the directories below the marked ones are automatically included as well.
@@ -327,19 +327,19 @@ $_CONFIG['log_file'] = "";
  */
 
 //
-// Algkataloogi suhteline aadress. Reeglina ei ole vaja muuta. 
+// Algkataloogi suhteline aadress. Reeglina ei ole vaja muuta.
 // Kasutage ainult suhtelisi alamkatalooge!
 // Vaikimisi: .
 //
 // The starting directory. Normally no need to change this.
-// Use only relative subdirectories! 
+// Use only relative subdirectories!
 // For example: $_CONFIG['starting_dir'] = "./mysubdir/";
 // Default: $_CONFIG['starting_dir'] = ".";
 //
 $_CONFIG['starting_dir'] = ".";
 
 //
-// Asukoht serveris. Tavaliselt ei ole vaja siia midagi panna kuna script leiab ise õige asukoha. 
+// Asukoht serveris. Tavaliselt ei ole vaja siia midagi panna kuna script leiab ise õige asukoha.
 // Mõnes serveris tuleb piirangute tõttu see aadress ise teistsuguseks määrata.
 // See fail peaks asuma serveris aadressil [AADRESS]/index.php
 // Aadress võib olla näiteks "/www/data/www.minudomeen.ee/minunimi"
@@ -360,14 +360,14 @@ $_CONFIG['basedir'] = "";
 $_CONFIG['large_files'] = false;
 
 //
-// Küpsise/sessiooni nimi. 
+// Küpsise/sessiooni nimi.
 // Anna sellele originaalne väärtus kui soovid samas ruumis kasutada mitut koopiat
 // ning ei taha, et toimuks andmete jagamist nende vahel.
 // Väärtus tohib sisaldada ainult tähti ja numbreid. Näiteks: MYSESSION1
 //
-// The session name, which is used as a cookie name. 
+// The session name, which is used as a cookie name.
 // Change this to something original if you have multiple copies in the same space
-// and wish to keep their authentication separate. 
+// and wish to keep their authentication separate.
 // The value can contain only letters and numbers. For example: MYSESSION1
 // More info at: http://www.php.net/manual/en/function.session-name.php
 // Default: $_CONFIG['session_name'] = "";
@@ -566,7 +566,7 @@ $_TRANSLATIONS["fr"] = array(
 	"username" => "Identifiant",
 	"log_in" => "Connexion",
 	"upload_type_not_allowed" => "Ce format de fichier n'est pas autorisé.",
-	"del" => "Effacer", 
+	"del" => "Effacer",
 	"log_out" => "Déconnexion"
 );
 
@@ -808,34 +808,34 @@ $_TRANSLATIONS["ro"] = array(
 
 // Russian
 $_TRANSLATIONS["ru"] = array(
-    "file_name" => "Имя файла",
-    "size" => "Размер",
-    "last_changed" => "Последнее изменение",
-    "total_used_space" => "Всего использовано",
-    "free_space" => "Свободно",
-    "password" => "Пароль",
-    "upload" => "Загрузка",
-    "failed_upload" => "Не удалось загрузить файл!",
-    "failed_move" => "Не удалось переместить файл в нужную папку!",
-    "wrong_password" => "Неверный пароль",
-    "make_directory" => "Новая папка",
-    "new_dir_failed" => "Не удалось создать папку",
-    "chmod_dir_failed" => "Не удалось изменить права доступа к папке",
-    "unable_to_read_dir" => "Не возможно прочитать папку",
-    "location" => "Расположение",
-    "root" => "Корневая папка",
-    "log_file_permission_error" => "Скрипт не имеет прав для записи лога файла.",
-    "upload_not_allowed" => "Загрузка в эту папку запрещена в настройках скрипта",
-    "upload_dir_not_writable" => "В эту папку запрещена запись",
-    "mobile_version" => "Мобильный вид",
-    "standard_version" => "Обычный вид",
-    "page_load_time" => "Страница загружена за %.2f мс.",
-    "wrong_pass" => "Неверное имя пользователя или пароль",
-    "username" => "Имя пользователя",
-    "log_in" => "Войти",
-    "upload_type_not_allowed" => "Этот тип файла запрещено загружать",
-    "del" => "удалить",
-    "log_out" => "выйти"
+	"file_name" => "Имя файла",
+	"size" => "Размер",
+	"last_changed" => "Последнее изменение",
+	"total_used_space" => "Всего использовано",
+	"free_space" => "Свободно",
+	"password" => "Пароль",
+	"upload" => "Загрузка",
+	"failed_upload" => "Не удалось загрузить файл!",
+	"failed_move" => "Не удалось переместить файл в нужную папку!",
+	"wrong_password" => "Неверный пароль",
+	"make_directory" => "Новая папка",
+	"new_dir_failed" => "Не удалось создать папку",
+	"chmod_dir_failed" => "Не удалось изменить права доступа к папке",
+	"unable_to_read_dir" => "Не возможно прочитать папку",
+	"location" => "Расположение",
+	"root" => "Корневая папка",
+	"log_file_permission_error" => "Скрипт не имеет прав для записи лога файла.",
+	"upload_not_allowed" => "Загрузка в эту папку запрещена в настройках скрипта",
+	"upload_dir_not_writable" => "В эту папку запрещена запись",
+	"mobile_version" => "Мобильный вид",
+	"standard_version" => "Обычный вид",
+	"page_load_time" => "Страница загружена за %.2f мс.",
+	"wrong_pass" => "Неверное имя пользователя или пароль",
+	"username" => "Имя пользователя",
+	"log_in" => "Войти",
+	"upload_type_not_allowed" => "Этот тип файла запрещено загружать",
+	"del" => "удалить",
+	"log_out" => "выйти"
 );
 
 // Slovensky
@@ -1009,7 +1009,7 @@ input {
 
 table.table {
 	width:100%;
-	border-collapse: collapse; 
+	border-collapse: collapse;
 }
 
 table.table td{
@@ -1035,7 +1035,7 @@ table.table td.del {
 }
 
 table.table tr.row td.size {
-	width: 100px; 
+	width: 100px;
 	text-align: right;
 }
 
@@ -1052,7 +1052,7 @@ table img{
 	border:0;
 }
 
-/* Info area */ 
+/* Info area */
 
 #info {
 	color:#000000;
@@ -1628,7 +1628,7 @@ class ImageServer
 			$etag = md5($mtime.$_SERVER['SCRIPT_FILENAME']);
 
 			if ((isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && $_SERVER['HTTP_IF_MODIFIED_SINCE'] == $mtime)
-				|| (isset($_SERVER['HTTP_IF_NONE_MATCH']) && str_replace('"', '', stripslashes($_SERVER['HTTP_IF_NONE_MATCH'])) == $etag)) 
+				|| (isset($_SERVER['HTTP_IF_NONE_MATCH']) && str_replace('"', '', stripslashes($_SERVER['HTTP_IF_NONE_MATCH'])) == $etag))
 			{
 				header('HTTP/1.1 304 Not Modified');
 				return true;
@@ -1654,26 +1654,26 @@ class ImageServer
 		}
 		return false;
 	}
-	
+
 	public static function isEnabledPdf()
 	{
 		if(class_exists("Imagick"))
 			return true;
 		return false;
 	}
-	
+
 	public static function openPdf($file)
 	{
 		if(!ImageServer::isEnabledPdf())
 			return null;
-			
+
 		$im = new Imagick($file.'[0]');
 		$im->setImageFormat( "png" );
 		$str = $im->getImageBlob();
 		$im2 = imagecreatefromstring($str);
 		return $im2;
 	}
-	
+
 	//
 	// Creates and returns a thumbnail image object from an image file
 	//
@@ -1683,7 +1683,7 @@ class ImageServer
 			$max_width = EncodeExplorer::getConfig('thumbnails_width');
 		else
 			$max_width = 200;
-		
+
 		if(is_int(EncodeExplorer::getConfig('thumbnails_height')))
 			$max_height = EncodeExplorer::getConfig('thumbnails_height');
 		else
@@ -1695,37 +1695,37 @@ class ImageServer
 			$image = ImageServer::openImage($file);
 		if($image == null)
 			return;
-			
+
 		imagealphablending($image, true);
 		imagesavealpha($image, true);
-			
+
 		$width = imagesx($image);
 		$height = imagesy($image);
-			
+
 		$new_width = $max_width;
 		$new_height = $max_height;
 		if(($width/$height) > ($new_width/$new_height))
 			$new_height = $new_width * ($height / $width);
-		else 
-			$new_width = $new_height * ($width / $height);   
-		
+		else
+			$new_width = $new_height * ($width / $height);
+
 		if($new_width >= $width && $new_height >= $height)
 		{
 			$new_width = $width;
 			$new_height = $height;
 		}
-		
+
 		$new_image = ImageCreateTrueColor($new_width, $new_height);
 		imagealphablending($new_image, true);
 		imagesavealpha($new_image, true);
 		$trans_colour = imagecolorallocatealpha($new_image, 0, 0, 0, 127);
 		imagefill($new_image, 0, 0, $trans_colour);
-		
+
 		imagecopyResampled ($new_image, $image, 0, 0, 0, 0, $new_width, $new_height, $width, $height);
-		
+
 		return $new_image;
 	}
-	
+
 	//
 	// Function for displaying the thumbnail.
 	// Includes attempts at cacheing it so that generation is minimised.
@@ -1736,11 +1736,11 @@ class ImageServer
 			$mtime = gmdate('r', filemtime($_SERVER['SCRIPT_FILENAME']));
 		else
 			$mtime = gmdate('r', filemtime($file));
-			
+
 		$etag = md5($mtime.$file);
-		
+
 		if ((isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && $_SERVER['HTTP_IF_MODIFIED_SINCE'] == $mtime)
-			|| (isset($_SERVER['HTTP_IF_NONE_MATCH']) && str_replace('"', '', stripslashes($_SERVER['HTTP_IF_NONE_MATCH'])) == $etag)) 
+			|| (isset($_SERVER['HTTP_IF_NONE_MATCH']) && str_replace('"', '', stripslashes($_SERVER['HTTP_IF_NONE_MATCH'])) == $etag))
 		{
 			header('HTTP/1.1 304 Not Modified');
 			return;
@@ -1754,15 +1754,15 @@ class ImageServer
 			imagepng($image);
 		}
 	}
-	
+
 	//
 	// A helping function for opening different types of image files
 	//
-	public static function openImage ($file) 
+	public static function openImage ($file)
 	{
-	    $size = getimagesize($file);
-	    switch($size["mime"])
-	    {
+		$size = getimagesize($file);
+		switch($size["mime"])
+		{
 			case "image/jpeg":
 				$im = imagecreatefromjpeg($file);
 			break;
@@ -1775,8 +1775,8 @@ class ImageServer
 			default:
 				$im=null;
 			break;
-	    }
-	    return $im;
+		}
+		return $im;
 	}
 }
 
@@ -1799,7 +1799,7 @@ class Logger
 				$encodeExplorer->setErrorString("log_file_permission_error");
 		}
 	}
-	
+
 	public static function logAccess($path, $isDir)
 	{
 		$message = $_SERVER['REMOTE_ADDR']." ".GateKeeper::getUserName()." accessed ";
@@ -1807,7 +1807,7 @@ class Logger
 		$message .= " ".$path;
 		Logger::log($message);
 	}
-	
+
 	public static function logQuery()
 	{
 		if(isset($_POST['log']) && strlen($_POST['log']) > 0)
@@ -1818,7 +1818,7 @@ class Logger
 		else
 			return false;
 	}
-	
+
 	public static function logCreation($path, $isDir)
 	{
 		$message = $_SERVER['REMOTE_ADDR']." ".GateKeeper::getUserName()." created ";
@@ -1826,7 +1826,7 @@ class Logger
 		$message .= " ".$path;
 		Logger::log($message);
 	}
-	
+
 	public static function emailNotification($path, $isFile)
 	{
 		if(strlen(EncodeExplorer::getConfig('upload_email')) > 0)
@@ -1850,18 +1850,18 @@ class GateKeeper
 		global $encodeExplorer;
 		if(strlen(EncodeExplorer::getConfig("session_name")) > 0)
 				session_name(EncodeExplorer::getConfig("session_name"));
-				
+
 		if(count(EncodeExplorer::getConfig("users")) > 0)
-			session_start();			
+			session_start();
 		else
 			return;
-			
+
 		if(isset($_GET['logout']))
 		{
 			$_SESSION['ee_user_name'] = null;
 			$_SESSION['ee_user_pass'] = null;
 		}
-			
+
 		if(isset($_POST['user_pass']) && strlen($_POST['user_pass']) > 0)
 		{
 			if(GateKeeper::isUser((isset($_POST['user_name'])?$_POST['user_name']:""), $_POST['user_pass']))
@@ -1889,7 +1889,7 @@ class GateKeeper
 				$encodeExplorer->setErrorString("wrong_pass");
 		}
 	}
-	
+
 	public static function isUser($userName, $userPass)
 	{
 		foreach(EncodeExplorer::getConfig("users") as $user)
@@ -1904,7 +1904,7 @@ class GateKeeper
 		}
 		return false;
 	}
-	
+
 	public static function isLoginRequired()
 	{
 		if(EncodeExplorer::getConfig("require_login") == false){
@@ -1912,7 +1912,7 @@ class GateKeeper
 		}
 		return true;
 	}
-	
+
 	public static function isUserLoggedIn()
 	{
 		if(isset($_SESSION['ee_user_name'], $_SESSION['ee_user_pass']))
@@ -1922,32 +1922,32 @@ class GateKeeper
 		}
 		return false;
 	}
-	
+
 	public static function isAccessAllowed()
 	{
 		if(!GateKeeper::isLoginRequired() || GateKeeper::isUserLoggedIn())
 			return true;
 		return false;
 	}
-	
+
 	public static function isUploadAllowed(){
 		if(EncodeExplorer::getConfig("upload_enable") == true && GateKeeper::isUserLoggedIn() == true && GateKeeper::getUserStatus() == "admin")
 			return true;
 		return false;
 	}
-	
+
 	public static function isNewdirAllowed(){
 		if(EncodeExplorer::getConfig("newdir_enable") == true && GateKeeper::isUserLoggedIn() == true && GateKeeper::getUserStatus() == "admin")
 			return true;
 		return false;
 	}
-	
+
 	public static function isDeleteAllowed(){
 		if(EncodeExplorer::getConfig("delete_enable") == true && GateKeeper::isUserLoggedIn() == true && GateKeeper::getUserStatus() == "admin")
 			return true;
 		return false;
 	}
-	
+
 	public static function getUserStatus(){
 		if(GateKeeper::isUserLoggedIn() == true && EncodeExplorer::getConfig("users") != null && is_array(EncodeExplorer::getConfig("users"))){
 			foreach(EncodeExplorer::getConfig("users") as $user){
@@ -1957,7 +1957,7 @@ class GateKeeper
 		}
 		return null;
 	}
-	
+
 	public static function getUserName()
 	{
 		if(GateKeeper::isUserLoggedIn() == true && isset($_SESSION['ee_user_name']) && strlen($_SESSION['ee_user_name']) > 0)
@@ -1968,7 +1968,7 @@ class GateKeeper
 			return $_SERVER['PHP_AUTH_USER'];
 		return "an anonymous user";
 	}
-	
+
 	public static function showLoginBox(){
 		if(!GateKeeper::isUserLoggedIn() && count(EncodeExplorer::getConfig("users")) > 0)
 			return true;
@@ -1976,7 +1976,7 @@ class GateKeeper
 	}
 }
 
-// 
+//
 // The class for any kind of file managing (new folder, upload, etc).
 //
 class FileManager
@@ -2006,7 +2006,7 @@ class FileManager
 			{
 				$dirname = str_replace($forbidden[$i], "", $dirname);
 			}
-			
+
 			if(!$location->uploadAllowed())
 			{
 				// The system configuration does not allow uploading here
@@ -2045,12 +2045,12 @@ class FileManager
 
 		$upload_dir = $location->getFullPath();
 		$upload_file = $upload_dir . $name;
-		
+
 		if(function_exists("finfo_open") && function_exists("finfo_file"))
 			$mime_type = File::getFileMime($userfile['tmp_name']);
 		else
 			$mime_type = $userfile['type'];
-	
+
 		$extension = File::getFileExtension($userfile['name']);
 
 		if(!$location->uploadAllowed())
@@ -2084,15 +2084,15 @@ class FileManager
 			Logger::emailNotification($location->getDir(true, false, false, 0).$name, true);
 		}
 	}
-	
+
 	public static function delete_dir($dir) {
 		if (is_dir($dir)) {
 			$objects = scandir($dir);
 			foreach ($objects as $object) {
 				if ($object != "." && $object != "..") {
-					if (filetype($dir."/".$object) == "dir") 
-						FileManager::delete_dir($dir."/".$object); 
-					else 
+					if (filetype($dir."/".$object) == "dir")
+						FileManager::delete_dir($dir."/".$object);
+					else
 						unlink($dir."/".$object);
 				}
 			}
@@ -2100,7 +2100,7 @@ class FileManager
 			rmdir($dir);
 		}
 	}
-	
+
 	public static function delete_file($file){
 		if(is_file($file)){
 			unlink($file);
@@ -2109,7 +2109,7 @@ class FileManager
 
 	//
 	// The main function, checks if the user wants to perform any supported operations
-	// 
+	//
 	function run($location)
 	{
 		if(isset($_POST['userdir']) && strlen($_POST['userdir']) > 0){
@@ -2117,13 +2117,13 @@ class FileManager
 				$this->newFolder($location, $_POST['userdir']);
 			}
 		}
-			
+
 		if(isset($_FILES['userfile']['name']) && strlen($_FILES['userfile']['name']) > 0){
 			if($location->uploadAllowed() && GateKeeper::isUserLoggedIn() && GateKeeper::isAccessAllowed() && GateKeeper::isUploadAllowed()){
 				$this->uploadFile($location, $_FILES['userfile']);
 			}
 		}
-		
+
 		if(isset($_GET['del'])){
 			if(GateKeeper::isUserLoggedIn() && GateKeeper::isAccessAllowed() && GateKeeper::isDeleteAllowed()){
 				$split_path = Location::splitPath($_GET['del']);
@@ -2135,7 +2135,7 @@ class FileManager
 				}
 				if($path == "" || $path == "/" || $path == "\\" || $path == ".")
 					return;
-				
+
 				if(is_dir($path))
 					FileManager::delete_dir($path);
 				else if(is_file($path))
@@ -2155,7 +2155,7 @@ class Dir
 
 	//
 	// Constructor
-	// 
+	//
 	function Dir($name, $location)
 	{
 		$this->name = $name;
@@ -2179,7 +2179,7 @@ class Dir
 
 	//
 	// Debugging output
-	// 
+	//
 	function debug()
 	{
 		print("Dir name (htmlspecialchars): ".$this->getName()."\n");
@@ -2201,12 +2201,12 @@ class File
 
 	//
 	// Constructor
-	// 
+	//
 	function File($name, $location)
 	{
 		$this->name = $name;
 		$this->location = $location;
-		
+
 		$this->type = File::getFileType($this->location->getDir(true, false, false, 0).$this->getName());
 		$this->size = File::getFileSize($this->location->getDir(true, false, false, 0).$this->getName());
 		$this->modTime = filemtime($this->location->getDir(true, false, false, 0).$this->getName());
@@ -2236,7 +2236,7 @@ class File
 	{
 		return $this->type;
 	}
-	
+
 	function getModTime()
 	{
 		return $this->modTime;
@@ -2244,7 +2244,7 @@ class File
 
 	//
 	// Determine the size of a file
-	// 
+	//
 	public static function getFileSize($file)
 	{
 		$sizeInBytes = filesize($file);
@@ -2255,20 +2255,20 @@ class File
 		}
 		return $sizeInBytes;
 	}
-	
+
 	public static function getFileType($filepath)
 	{
 		/*
 		 * This extracts the information from the file contents.
 		 * Unfortunately it doesn't properly detect the difference between text-based file types.
-		 * 
+		 *
 		$mime_type = File::getMimeType($filepath);
 		$mime_type_chunks = explode("/", $mime_type, 2);
 		$type = $mime_type_chunks[1];
 		*/
 		return File::getFileExtension($filepath);
 	}
-	
+
 	public static function getFileMime($filepath)
 	{
 		$fhandle = finfo_open(FILEINFO_MIME);
@@ -2279,7 +2279,7 @@ class File
 		$mime_type = $mime_type_chunks[0];
 		return $mime_type;
 	}
-	
+
 	public static function getFileExtension($filepath)
 	{
 		return strtolower(pathinfo($filepath, PATHINFO_EXTENSION));
@@ -2287,7 +2287,7 @@ class File
 
 	//
 	// Debugging output
-	// 
+	//
 	function debug()
 	{
 		print("File name: ".$this->getName()."\n");
@@ -2295,7 +2295,7 @@ class File
 		print("File size: ".$this->size."\n");
 		print("File modTime: ".$this->modTime."\n");
 	}
-	
+
 	function isImage()
 	{
 		$type = $this->getType();
@@ -2303,21 +2303,21 @@ class File
 			return true;
 		return false;
 	}
-	
+
 	function isPdf()
 	{
 		if(strtolower($this->getType()) == "pdf")
 			return true;
-		return false;		
+		return false;
 	}
-	
+
 	public static function isPdfFile($file)
 	{
 		if(File::getFileType($file) == "pdf")
 			return true;
 		return false;
 	}
-	
+
 	function isValidForThumb()
 	{
 		if($this->isImage() || ($this->isPdf() && ImageServer::isEnabledPdf()))
@@ -2332,7 +2332,7 @@ class Location
 
 	//
 	// Split a file path into array elements
-	// 
+	//
 	public static function splitPath($dir)
 	{
 		$dir = stripslashes($dir);
@@ -2350,7 +2350,7 @@ class Location
 	//
 	// Get the current directory.
 	// Options: Include the prefix ("./"); URL-encode the string; HTML-encode the string; return directory n-levels up
-	// 
+	//
 	function getDir($prefix, $encoded, $html, $up)
 	{
 		$dir = "";
@@ -2383,7 +2383,7 @@ class Location
 
 	//
 	// Debugging output
-	// 
+	//
 	function debug()
 	{
 		print_r($this->path);
@@ -2396,7 +2396,7 @@ class Location
 
 	//
 	// Set the current directory
-	// 
+	//
 	function init()
 	{
 		if(!isset($_GET['dir']) || strlen($_GET['dir']) == 0)
@@ -2408,7 +2408,7 @@ class Location
 			$this->path = $this->splitPath($_GET['dir']);
 		}
 	}
-	
+
 	//
 	// Checks if the current directory is below the input path
 	//
@@ -2421,7 +2421,7 @@ class Location
 		}
 		return false;
 	}
-	
+
 	//
 	// Check if uploading is allowed into the current directory, based on the configuration
 	//
@@ -2431,7 +2431,7 @@ class Location
 			return false;
 		if(EncodeExplorer::getConfig('upload_dirs') == null || count(EncodeExplorer::getConfig('upload_dirs')) == 0)
 			return true;
-			
+
 		$upload_dirs = EncodeExplorer::getConfig('upload_dirs');
 		for($i = 0; $i < count($upload_dirs); $i++)
 		{
@@ -2440,17 +2440,17 @@ class Location
 		}
 		return false;
 	}
-	
+
 	function isWritable()
 	{
 		return is_writable($this->getDir(true, false, false, 0));
 	}
-	
+
 	public static function isDirWritable($dir)
 	{
 		return is_writable($dir);
 	}
-	
+
 	public static function isFileWritable($file)
 	{
 		if(file_exists($file))
@@ -2478,10 +2478,10 @@ class EncodeExplorer
 	var $logging;
 	var $spaceUsed;
 	var $lang;
-	
+
 	//
 	// Determine sorting, calculate space.
-	// 
+	//
 	function init()
 	{
 		$this->sort_by = "";
@@ -2500,21 +2500,21 @@ class EncodeExplorer
 			$this->sort_by = "name";
 			$this->sort_as = "desc";
 		}
-		
-		
+
+
 		global $_TRANSLATIONS;
 		if(isset($_GET['lang'], $_TRANSLATIONS[$_GET['lang']]))
 			$this->lang = $_GET['lang'];
 		else
 			$this->lang = EncodeExplorer::getConfig("lang");
-		
+
 		$this->mobile = false;
 		if(EncodeExplorer::getConfig("mobile_enabled") == true)
 		{
 			if((EncodeExplorer::getConfig("mobile_default") == true || isset($_GET['m'])) && !isset($_GET['s']))
 				$this->mobile = true;
 		}
-		
+
 		$this->logging = false;
 		if(EncodeExplorer::getConfig("log_file") != null && strlen(EncodeExplorer::getConfig("log_file")) > 0)
 			$this->logging = true;
@@ -2522,7 +2522,7 @@ class EncodeExplorer
 
 	//
 	// Read the file list from the directory
-	// 
+	//
 	function readDir()
 	{
 		global $encodeExplorer;
@@ -2535,7 +2535,7 @@ class EncodeExplorer
 			$this->files = array();
 			while ($object = readdir($open_dir))
 			{
-				if($object != "." && $object != "..") 
+				if($object != "." && $object != "..")
 				{
 					if(is_dir($this->location->getDir(true, false, false, 0)."/".$object))
 					{
@@ -2556,27 +2556,27 @@ class EncodeExplorer
 
 	//
 	// A recursive function for calculating the total used space
-	// 
-	function sum_dir($start_dir, $ignore_files, $levels = 1) 
+	//
+	function sum_dir($start_dir, $ignore_files, $levels = 1)
 	{
-		if ($dir = opendir($start_dir)) 
+		if ($dir = opendir($start_dir))
 		{
 			$total = 0;
-			while ((($file = readdir($dir)) !== false)) 
+			while ((($file = readdir($dir)) !== false))
 			{
-				if (!in_array($file, $ignore_files)) 
+				if (!in_array($file, $ignore_files))
 				{
-					if ((is_dir($start_dir . '/' . $file)) && ($levels - 1 >= 0)) 
+					if ((is_dir($start_dir . '/' . $file)) && ($levels - 1 >= 0))
 					{
 						$total += $this->sum_dir($start_dir . '/' . $file, $ignore_files, $levels-1);
 					}
-					elseif (is_file($start_dir . '/' . $file)) 
-					{					
+					elseif (is_file($start_dir . '/' . $file))
+					{
 						$total += File::getFileSize($start_dir . '/' . $file) / 1024;
 					}
 				}
 			}
-			
+
 			closedir($dir);
 			return $total;
 		}
@@ -2599,7 +2599,7 @@ class EncodeExplorer
 			if($this->sort_as == "desc")
 				$this->files = array_reverse($this->files);
 		}
-		
+
 		if(is_array($this->dirs)){
 			usort($this->dirs, "EncodeExplorer::cmp_name");
 			if($this->sort_by == "name" && $this->sort_as == "desc")
@@ -2608,7 +2608,7 @@ class EncodeExplorer
 	}
 
 	function makeArrow($sort_by)
-	{	
+	{
 		if($this->sort_by == $sort_by && $this->sort_as == "asc")
 		{
 			$sort_as = "desc";
@@ -2630,7 +2630,7 @@ class EncodeExplorer
 		return "<a href=\"".$this->makeLink(false, false, $sort_by, $sort_as, null, $this->location->getDir(false, true, false, 0))."\">
 			$text <img style=\"border:0;\" alt=\"".$sort_as."\" src=\"?img=".$img."\" /></a>";
 	}
-	
+
 	function makeLink($switchVersion, $logout, $sort_by, $sort_as, $delete, $dir)
 	{
 		$link = "?";
@@ -2645,22 +2645,22 @@ class EncodeExplorer
 			$link .= "m&amp;";
 		else if($this->mobile == false && EncodeExplorer::getConfig("mobile_enabled") == true && EncodeExplorer::getConfig("mobile_default") == true)
 			$link .= "s&amp;";
-			
+
 		if($logout == true)
 		{
 			$link .= "logout";
 			return $link;
 		}
-			
+
 		if(isset($this->lang) && $this->lang != EncodeExplorer::getConfig("lang"))
 			$link .= "lang=".$this->lang."&amp;";
-			
+
 		if($sort_by != null && strlen($sort_by) > 0)
 			$link .= "sort_by=".$sort_by."&amp;";
-			
+
 		if($sort_as != null && strlen($sort_as) > 0)
 			$link .= "sort_as=".$sort_as."&amp;";
-		
+
 		$link .= "dir=".$dir;
 		if($delete != null)
 			$link .= "&amp;del=".$delete;
@@ -2681,11 +2681,11 @@ class EncodeExplorer
 		return date($timeformat, $time);
 	}
 
-	function formatSize($size) 
+	function formatSize($size)
 	{
 		$sizes = Array('B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB');
 		$y = $sizes[0];
-		for ($i = 1; (($i < count($sizes)) && ($size >= 1024)); $i++) 
+		for ($i = 1; (($i < count($sizes)) && ($size >= 1024)); $i++)
 		{
 			$size = $size / 1024;
 			$y  = $sizes[$i];
@@ -2695,7 +2695,7 @@ class EncodeExplorer
 
 	//
 	// Debugging output
-	// 
+	//
 	function debug()
 	{
 		print("Explorer location: ".$this->location->getDir(true, false, false, 0)."\n");
@@ -2704,26 +2704,26 @@ class EncodeExplorer
 		for($i = 0; $i < count($this->files); $i++)
 			$this->files[$i]->output();
 	}
-	
+
 	//
 	// Comparison functions for sorting.
 	//
-	
+
 	public static function cmp_name($b, $a)
 	{
 		return strcasecmp($a->name, $b->name);
 	}
-	
+
 	public static function cmp_size($a, $b)
 	{
 		return ($a->size - $b->size);
 	}
-	
+
 	public static function cmp_mod($b, $a)
 	{
 		return ($a->modTime - $b->modTime);
 	}
-	
+
 	//
 	// The function for getting a translated string.
 	// Falls back to english if the correct language is missing something.
@@ -2731,21 +2731,21 @@ class EncodeExplorer
 	public static function getLangString($stringName, $lang)
 	{
 		global $_TRANSLATIONS;
-		if(isset($_TRANSLATIONS[$lang]) && is_array($_TRANSLATIONS[$lang]) 
+		if(isset($_TRANSLATIONS[$lang]) && is_array($_TRANSLATIONS[$lang])
 			&& isset($_TRANSLATIONS[$lang][$stringName]))
 			return $_TRANSLATIONS[$lang][$stringName];
-		else if(isset($_TRANSLATIONS["en"]))// && is_array($_TRANSLATIONS["en"]) 
+		else if(isset($_TRANSLATIONS["en"]))// && is_array($_TRANSLATIONS["en"])
 			//&& isset($_TRANSLATIONS["en"][$stringName]))
 			return $_TRANSLATIONS["en"][$stringName];
 		else
 			return "Translation error";
 	}
-	
+
 	function getString($stringName)
 	{
 		return EncodeExplorer::getLangString($stringName, $this->lang);
 	}
-	
+
 	//
 	// The function for getting configuration values
 	//
@@ -2756,7 +2756,7 @@ class EncodeExplorer
 			return $_CONFIG[$name];
 		return null;
 	}
-	
+
 	public static function setError($message)
 	{
 		global $_ERROR;
@@ -2765,7 +2765,7 @@ class EncodeExplorer
 		else
 			$_ERROR = $message;
 	}
-	
+
 	function setErrorString($stringName)
 	{
 		EncodeExplorer::setError($this->getString($stringName));
@@ -2773,7 +2773,7 @@ class EncodeExplorer
 
 	//
 	// Main function, activating tasks
-	// 
+	//
 	function run($location)
 	{
 		$this->location = $location;
@@ -2782,13 +2782,13 @@ class EncodeExplorer
 		$this->sort();
 		$this->outputHtml();
 	}
-	
+
 	public function printLoginBox()
 	{
 		?>
 		<div id="login">
 		<form enctype="multipart/form-data" action="<?php print $this->makeLink(false, false, null, null, null, ""); ?>" method="post">
-		<?php 
+		<?php
 		if(GateKeeper::isLoginRequired())
 		{
 			$require_username = false;
@@ -2803,7 +2803,7 @@ class EncodeExplorer
 			?>
 			<div><label for="user_name"><?php print $this->getString("username"); ?>:</label>
 			<input type="text" name="user_name" value="" id="user_name" /></div>
-			<?php 
+			<?php
 			}
 			?>
 			<div><label for="user_pass"><?php print $this->getString("password"); ?>:</label>
@@ -2811,13 +2811,13 @@ class EncodeExplorer
 			<div><input type="submit" value="<?php print $this->getString("log_in"); ?>" class="button" /></div>
 		</form>
 		</div>
-	<?php 
+	<?php
 		}
 	}
 
 	//
 	// Printing the actual page
-	// 
+	//
 	function outputHtml()
 	{
 		global $_ERROR;
@@ -2834,7 +2834,7 @@ class EncodeExplorer
 if(($this->getConfig('log_file') != null && strlen($this->getConfig('log_file')) > 0)
 	|| ($this->getConfig('thumbnails') != null && $this->getConfig('thumbnails') == true && $this->mobile == false)
 	|| (GateKeeper::isDeleteAllowed()))
-{ 
+{
 ?>
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js"></script>
 <script type="text/javascript">
@@ -2848,27 +2848,27 @@ $(document).ready(function() {
 		var answer = confirm('Are you sure you want to delete : \'' + $(this).attr("data-name") + "\' ?");
 		return answer;
 	});
-<?php 
-	}	
+<?php
+	}
 	if($this->logging == true)
-	{ 
+	{
 ?>
 		function logFileClick(path)
 		{
 			 $.ajax({
-		        	async: false,
+					async: false,
 					type: "POST",
 					data: {log: path},
 					contentType: "application/x-www-form-urlencoded; charset=UTF-8",
 					cache: false
 				});
 		}
-		
+
 		$("a.file").click(function(){
 			logFileClick("<?php print $this->location->getDir(true, true, false, 0);?>" + $(this).html());
 			return true;
 		});
-<?php 
+<?php
 	}
 	if(EncodeExplorer::getConfig("thumbnails") == true && $this->mobile == false)
 	{
@@ -2881,10 +2881,10 @@ $(document).ready(function() {
 			diff = 0;
 			if(e.clientY + $("#thumb").height() > $(window).height())
 				diff = e.clientY + $("#thumb").height() - $(window).height();
-			
+
 			$("#thumb").css("top",(e.pageY - yOffset - diff) + "px");
 		}
-		
+
 		$("a.thumb").hover(function(e){
 			$("#thumb").remove();
 			$("body").append("<div id=\"thumb\"><img src=\"?thumb="+ $(this).attr("href") +"\" alt=\"Preview\" \/><\/div>");
@@ -2900,19 +2900,19 @@ $(document).ready(function() {
 			});
 
 		$("a.thumb").click(function(e){$("#thumb").remove(); return true;});
-<?php 
+<?php
 	}
 ?>
 	});
-//]]>                
+//]]>
 </script>
-<?php 
+<?php
 }
 ?>
 <title><?php if(EncodeExplorer::getConfig('main_title') != null) print EncodeExplorer::getConfig('main_title'); ?></title>
 </head>
 <body class="<?php print ($this->mobile == true?"mobile":"standard");?>">
-<?php 
+<?php
 //
 // Print the error (if there is something to print)
 //
@@ -2928,7 +2928,7 @@ if(EncodeExplorer::getConfig('show_top') == true)
 ?>
 <div id="top">
 	<a href="<?php print $this->makeLink(false, false, null, null, null, ""); ?>"><span><?php if(EncodeExplorer::getConfig('main_title') != null) print EncodeExplorer::getConfig('main_title'); ?></span></a>
-<?php 
+<?php
 if(EncodeExplorer::getConfig("secondary_titles") != null && is_array(EncodeExplorer::getConfig("secondary_titles")) && count(EncodeExplorer::getConfig("secondary_titles")) > 0 && $this->mobile == false)
 {
 	$secondary_titles = EncodeExplorer::getConfig("secondary_titles");
@@ -2944,7 +2944,7 @@ if(!GateKeeper::isAccessAllowed())
 {
 	$this->printLoginBox();
 }
-else 
+else
 {
 if($this->mobile == false && EncodeExplorer::getConfig("show_path") == true)
 {
@@ -2960,13 +2960,13 @@ if($this->mobile == false && EncodeExplorer::getConfig("show_path") == true)
 	}
 ?>
 </div>
-<?php 
+<?php
 }
 ?>
 
 <!-- START: List table -->
 <table class="table">
-<?php 
+<?php
 if($this->mobile == false)
 {
 ?>
@@ -2979,7 +2979,7 @@ if($this->mobile == false)
 	<td class="del"><?php print EncodeExplorer::getString("del"); ?></td>
 	<?php } ?>
 </tr>
-<?php 
+<?php
 }
 ?>
 <tr class="row two">
@@ -3068,7 +3068,7 @@ if($this->files)
 
 </table>
 <!-- END: List table -->
-<?php 
+<?php
 }
 ?>
 </div>
@@ -3088,7 +3088,7 @@ if(GateKeeper::isAccessAllowed() && GateKeeper::showLoginBox()){
 	</div>
 </form>
 <!-- END: Login area -->
-<?php 
+<?php
 }
 
 if(GateKeeper::isAccessAllowed() && $this->location->uploadAllowed() && (GateKeeper::isUploadAllowed() || GateKeeper::isNewdirAllowed()))
@@ -3097,14 +3097,14 @@ if(GateKeeper::isAccessAllowed() && $this->location->uploadAllowed() && (GateKee
 <!-- START: Upload area -->
 <form enctype="multipart/form-data" method="post">
 	<div id="upload">
-		<?php 
+		<?php
 		if(GateKeeper::isNewdirAllowed()){
 		?>
 		<div id="newdir_container">
 			<input name="userdir" type="text" class="upload_dirname" />
 			<input type="submit" value="<?php print $this->getString("make_directory"); ?>" />
 		</div>
-		<?php 
+		<?php
 		}
 		if(GateKeeper::isUploadAllowed()){
 		?>
@@ -3112,7 +3112,7 @@ if(GateKeeper::isAccessAllowed() && $this->location->uploadAllowed() && (GateKee
 			<input name="userfile" type="file" class="upload_file" />
 			<input type="submit" value="<?php print $this->getString("upload"); ?>" class="upload_sumbit" />
 		</div>
-		<?php 
+		<?php
 		}
 		?>
 		<div class="bar"></div>
@@ -3143,19 +3143,19 @@ if($this->mobile == false && $this->getConfig("show_load_time") == true)
 {
 	printf($this->getString("page_load_time")." | ", (microtime(TRUE) - $_START_TIME)*1000);
 }
-?> 
+?>
 <a href="http://encode-explorer.siineiolekala.net">Encode Explorer</a>
 </div>
 <!-- END: Info area -->
 </body>
 </html>
-	
+
 <?php
 	}
 }
 
 //
-// This is where the system is activated. 
+// This is where the system is activated.
 // We check if the user wants an image and show it. If not, we show the explorer.
 //
 $encodeExplorer = new EncodeExplorer();


### PR DESCRIPTION
**Cleanup whitespace**

Code had some extra whitespace before EOL that I've removed. Certain 4 space groups have been converted to tab char where applicable.

**Configurable chmod**

Using chmod 0777 for directories and 0755 for files is a security risk for two reasons:

1. Directories shouldn't be world-writable. Using 0755 is enough as long as directories are chown'ed correctly to the user account running PHP process.
2. Files uploaded by encode-explorer shouldn't be marked as executable as that opens a possible security risk as they might be executed instead of being just read when they are accessed via browser for download (this depends on webserver configuration with regards to CGI execution).

Two configurable settings were added, by default directories chmod is now 0755 and files chmod is 0644.

**PHP extensions**

By default only 'php' is disallowed. I have added more php file extensions used in cPanel/WHM configurations by default.



