### PR TITLE
Additional log and notification, more control on file access through PHP

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,8 @@
+IndexIgnore *
+Order Deny,Allow
+Deny from all
+
+<Files "index.php">
+	Allow from all
+</Files>
+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ You have to upload index.php into your server.
 If you open index.php you can edit several settings.
 You should make sure the edited file will be saved in UTF-8!
 
+An example of how to protect direct Access through .htaccess (apache):
+IndexIgnore *
+Order Deny,Allow
+Deny from all
+
+<Files "index.php">
+	Allow from all
+</Files>
+
 
 License
 ----------------------------------

--- a/README.md
+++ b/README.md
@@ -20,14 +20,8 @@ You have to upload index.php into your server.
 If you open index.php you can edit several settings.
 You should make sure the edited file will be saved in UTF-8!
 
-An example of how to protect direct Access through .htaccess (apache):
-IndexIgnore *
-Order Deny,Allow
-Deny from all
-
-<Files "index.php">
-	Allow from all
-</Files>
+An example of how to protect direct Access through .htaccess (apache)
+is available and must be adjusted to the webserver.
 
 
 License

--- a/index.php
+++ b/index.php
@@ -1950,6 +1950,14 @@ class Logger
 		Logger::log($message);
 	}
 
+	public static function logDeletion($path, $isDir)
+	{
+		$message = $_SERVER['REMOTE_ADDR']." ".GateKeeper::getUserName()." deleted ";
+		$message .= $isDir?"dir":"file";
+		$message .= " ".$path;
+		Logger::log($message);
+	}
+
 	public static function emailNotification($path, $isFile)
 	{
 		if(strlen(EncodeExplorer::getConfig('upload_email')) > 0)
@@ -1961,7 +1969,19 @@ class Logger
 			mail(EncodeExplorer::getConfig('upload_email'), "Upload notification", $message);
 		}
 	}
+	
+	public static function emailNotificationDeletion($path, $isFile)
+	{
+		if(strlen(EncodeExplorer::getConfig('upload_email')) > 0)
+		{
+			$message = "This is a message to let you know that ".GateKeeper::getUserName()." ";
+			$message .= ($isFile?"deleted a file":"deleted a directory")." in Encode Explorer.\n\n";
+			$message .= "Path : ".$path."\n";
+			$message .= "IP : ".$_SERVER['REMOTE_ADDR']."\n";
+			mail(EncodeExplorer::getConfig('delete_email'), "Deletion notification", $message);
 		}
+	}
+}
 
 //
 // The class controls logging in and authentication
@@ -2221,12 +2241,16 @@ class FileManager
 			}
 			reset($objects);
 			rmdir($dir);
+			Logger::logDeletion("./".$dir, true);
+			Logger::emailNotificationDeletion("./".$dir, false);
 		}
 	}
 
 	public static function delete_file($file){
 		if(is_file($file)){
 			unlink($file);
+			Logger::logDeletion("./".$file, false);
+			Logger::emailNotificationDeletion("./".$file, true);
 		}
 	}
 

--- a/index.php
+++ b/index.php
@@ -1728,6 +1728,10 @@ $_IMAGES["xls"] = $_IMAGES["spreadsheet"];
 $_IMAGES["xlsx"] = $_IMAGES["spreadsheet"];
 $_IMAGES["xml"] = $_IMAGES["code"];
 $_IMAGES["zip"] = $_IMAGES["archive"];
+$_IMAGES["download"] = "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAAAmJLR0QA/4ePzL8AAAAJcEhZcwAA
+CxMAAAsTAQCanBgAAAAHdElNRQfhAxUJJiDGyieZAAAAeklEQVQoz62QsQqAMAxEn7Wbn9NZP0Dw
+/0e/Qu0QGhcrTakI4mVIAncXLvCCzmz+6tImeyKCEG9ioclbX6tcMStquiEMuMLN4xis00hC0KuE
+xFgfC0QSipKIhFaKiQNFOZievhLY2dvqjIWFb1jvBLlW+8m5zs3GTzgBdP0qMaa27WIAAAAASUVO";
 
 /***************************************************************************/
 /*   HERE COMES THE CODE.                                                  */
@@ -3131,13 +3135,14 @@ if($this->mobile == false)
 	<?php if($this->mobile == false && GateKeeper::isDeleteAllowed()){?>
 	<td class="del"><?php print EncodeExplorer::getString("del"); ?></td>
 	<?php } ?>
+	<td class="icon">DL</td>
 </tr>
 <?php
 }
 ?>
 <tr class="row two">
 	<td class="icon"><img alt="dir" src="?img=directory" /></td>
-	<td colspan="<?php print (($this->mobile == true?1:(GateKeeper::isDeleteAllowed()?4:3))); ?>" class="long">
+	<td colspan="<?php print (($this->mobile == true?1:(GateKeeper::isDeleteAllowed()?5:4))); ?>" class="long">
 		<a class="item" href="<?php print $this->makeLink(false, false, null, null, null, $this->location->getDir(false, true, false, 1)); ?>">..</a>
 	</td>
 </tr>
@@ -3170,6 +3175,7 @@ if($this->dirs)
 		{
 			print "<td class=\"del\"><a data-name=\"".htmlentities($dir->getName())."\" href=\"".$this->makeLink(false, false, null, null, $this->location->getDir(false, true, false, 0).$dir->getNameEncoded(), $this->location->getDir(false, true, false, 0))."\"><img src=\"?img=del\" alt=\"Delete\" /></a></td>";
 		}
+		print "<td></td>";		
 		print "</tr>\n";
 		$row =! $row;
 	}
@@ -3214,6 +3220,12 @@ if($this->files)
 				</a>
 			</td>";
 		}
+		
+		print "<td class=\"icon\">";
+		print "<a href=\"".$this->location->getDir(false, true, false, 0).$file->getNameEncoded()."\" class=\"item file\" download>";
+		print "<img alt=\"download\" src=\"?img=download\" />";
+		print "</a></td>\n";
+		
 		print "</tr>\n";
 		$row =! $row;
 	}

--- a/index.php
+++ b/index.php
@@ -787,7 +787,7 @@ $_TRANSLATIONS["no"] = array(
 //Polish
 $_TRANSLATIONS["pl"] = array(
   "file_name" => "Nazwa pliku",
-  "size" => "Rozmiar",
+	"size" => "Rozmiar",
   "last_changed" => "Data zmiany",
   "total_used_space" => "Cała przestrzeń",
   "free_space" => "Wolna przestrzeń",
@@ -796,17 +796,17 @@ $_TRANSLATIONS["pl"] = array(
   "failed_upload" => "Przesłanie pliku nie powiodło się",
   "failed_move" => "Przenoszenie pliku nie powiodło się!",
   "wrong_password" => "Niepoprawne hasło",
-  "make_directory" => "Nowy folder",
+	"make_directory" => "Nowy folder",
   "new_dir_failed" => "Błąd podczas tworzenia nowego folderu",
   "chmod_dir_failed" => "Błąd podczas zmiany uprawnień folderu",
   "unable_to_read_dir" => "Odczytanie folderu nie powiodło się",
-  "location" => "Miejsce",
+	"location" => "Miejsce",
   "root" => "Start",
   "log_file_permission_error" => "Brak uprawnień aby utworzyć dziennik działań.",
   "upload_not_allowed" => "Konfiguracja zabrania przesłania pliku do tego folderu.",
   "upload_dir_not_writable" => "Nie można zapisać pliku do tego folderu.",
   "mobile_version" => "Wersja mobilna",
-  "standard_version" => "Widok standardowy",
+	"standard_version" => "Widok standardowy",
   "page_load_time" => "Załadowano w %.2f ms",
   "wrong_pass" => "Niepoprawna nazwa użytkownika lub złe hasło",
   "username" => "Użytkownik",
@@ -1961,7 +1961,7 @@ class Logger
 			mail(EncodeExplorer::getConfig('upload_email'), "Upload notification", $message);
 		}
 	}
-}
+		}
 
 //
 // The class controls logging in and authentication
@@ -2265,8 +2265,8 @@ class FileManager
 					FileManager::delete_file($path);
 			}
 		}
-	}
-}
+			}
+		}
 
 //
 // Dir class holds the information about one directory in the list
@@ -2626,7 +2626,7 @@ class EncodeExplorer
 		if(function_exists('date_default_timezone_get') && function_exists('date_default_timezone_set'))
 		{
 			@date_default_timezone_set(date_default_timezone_get());
-		}
+				}
 
 		if(isset($_GET['lang']) && is_scalar($_GET['lang']) && isset($_TRANSLATIONS[$_GET['lang']]))
 			$this->lang = $_GET['lang'];
@@ -2726,8 +2726,8 @@ class EncodeExplorer
 			usort($this->dirs, array('EncodeExplorer', 'cmp_'.$sort_by));
 			if($this->sort_as == "desc") {
 				$this->dirs = array_reverse($this->dirs);
-			}
 		}
+	}
 
 		// Here we filter the comparison functions supported by our file object
 		$sort_by = in_array($this->sort_by, array('name', 'size', 'mod')) ? $this->sort_by : 'name';
@@ -2736,7 +2736,7 @@ class EncodeExplorer
 			usort($this->files, array('EncodeExplorer', 'cmp_'.$sort_by));
 			if($this->sort_as == "desc") {
 				$this->files = array_reverse($this->files);
-			}
+		}
 		}
 	}
 
@@ -3230,7 +3230,7 @@ if(GateKeeper::isAccessAllowed() && $this->location->uploadAllowed() && (GateKee
 {
 ?>
 <!-- START: Upload area -->
-<form enctype="multipart/form-data" method="post">
+<form enctype="multipart/form-data" method="post" <?=isset($_GET['dir'])? 'action="?dir='.$_GET['dir'].'">' : ''?>>
 	<div id="upload">
 		<?php
 		if(GateKeeper::isNewdirAllowed()){


### PR DESCRIPTION
Hi,
first of all I would like to thank you!
I was using encode-explorer already quite a bit with a few changes - and now due to updating I felt it might be worth sharing what I did.

Regarding the .htaccess:
While I didn't want to have an additional file in the project, I had problems displaying the Lines in the Readme.
I think it would be nice to have also an example for an nginx like configuration.

Explanation for the Download on the right side:
I had to provide a lot of images and because it wasn't me who had to work with, I wanted to ease the job for the one who had to. (And no, packaging all pictures for one simple download wasn't an option :P)

Explanation regarding the php processed download:
with the php processed download your script has to provide the data, this way you can fully log and permit/deny access to the files, but the provider has to setup rules through htaccess or otherwise configs.
Problem as noted could be a php timeout, but it didn't happen to me yet.
Probably it would be better providing this functionality with an additional option, but on the other hand if a login is required, and you provide rules to protect your files, there shouldn't be a way around.