### PR TITLE
Language specific name sorting

### DIFF
--- a/index.php
+++ b/index.php
@@ -2840,8 +2840,9 @@ class EncodeExplorer
 	//
 
 	public static function cmp_name($a, $b)
-	{
-		return strcasecmp($a->name, $b->name);
+	{		
+		$coll = collator_create( EncodeExplorer::getConfig("lang") );
+		return $res  = collator_compare( $coll, $a->name, $b->name );
 	}
 
 	public static function cmp_size($a, $b)


### PR DESCRIPTION
Currently, the problem is that file and directory names are not sorted correctly. If charset is set to UTF-8,  strcasecmp fails to sort them in the correct order. I modified cmp_name function to address this problem: firstly, it creates a collator using the language set in $_CONFIG, then uses it in collator_compare to compare two strings. 

I guess there should be different cases for different charsets, at least for unicode and non-unicode, so any help is appreciated. 